### PR TITLE
Running zope as a different user

### DIFF
--- a/init_scripts/RedHat-FedoraCore/plone-cluster-user
+++ b/init_scripts/RedHat-FedoraCore/plone-cluster-user
@@ -1,0 +1,82 @@
+#!/bin/sh
+# /etc/rc.d/init.d/zeocluster
+# Startup script for Zope with ZEOCluster
+#
+# This script works on Red Hat / Fedora Core style Linuxes
+#
+# chkconfig: 345 80 20
+# description: Zope, a web application server
+# this works as is for a default universal plone linux install
+#
+# Typical installation:
+# sudo cp plone-cluster /etc/rc.d/init.d/plone
+# sudo chmod 755 /etc/rc.d/init.d/plone
+# sudo /sbin/chkconfig --add plone
+#
+# Typical removal:
+# sudo /sbin/chkconfig --del plone
+#
+# config: /usr/local/plone/zeocluster/buildout.cfg
+
+# Source function library.
+if [ -f /etc/init.d/functions ] ; then
+        . /etc/init.d/functions
+elif [ -f /etc/rc.d/init.d/functions ] ; then
+        . /etc/rc.d/init.d/functions
+else
+        exit 0
+fi
+
+RETVAL=0
+# list zeo clients in the list below
+zeoclients="client1 client2"
+# this is for the default install path for Plone-3.0-buildout
+clusterpath="/usr/local/Plone/zeocluster"
+prog="plone"
+user="plone_daemon"
+
+start() {
+    echo -n $"Starting $prog zeo server: "
+    daemon --user=$user ${clusterpath}/bin/plonectl start
+    return $?
+}
+
+stop() {
+    echo -n $"Stopping $prog zeo server: "
+    daemon --user=$user ${clusterpath}/bin/plonectl stop
+    return $?
+}
+
+status() {
+    echo "ZEO Server:"
+    ${clusterpath}/bin/plonectl status
+    return $?
+}
+
+restart() {
+   stop
+   start
+}
+
+case "$1" in
+  start)
+    start
+    ;;
+  stop)
+    stop
+    ;;
+  status)
+    status
+    ;;
+  restart)
+    restart
+    ;;
+  condrestart)
+    [ -e /var/lock/subsys/$prog ] && restart
+    ;;
+  *)
+    echo $"Usage: $0 {start|stop|status|restart|condrestart}"
+    RETVAL=2
+esac
+
+exit $RETVAL


### PR DESCRIPTION
This init-script uses "daemon" function to run the plonectl script as the "plone_daemon" user, as recommended by plone 4.3 setup.
Also I move the status lines to a function. There's a warning with the "return" call when is used outside a function.
