### PR TITLE
Link README.rst to README.txt

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,0 +1,1 @@
+README.txt


### PR DESCRIPTION
Github render correctly README.rst but it's only a link to README.txt
