### PR TITLE
Add checkdocs to develop.cfg

### DIFF
--- a/base_skeleton/develop.cfg
+++ b/base_skeleton/develop.cfg
@@ -117,6 +117,7 @@ eggs +=
 parts +=
     test
     diazotools
+    checkdocs
     zopeskel
 
 # mr.developer settings:
@@ -140,6 +141,11 @@ eggs =
 recipe = zc.recipe.egg
 eggs = diazo
 
+[checkdocs]
+# installs collective.checkdocs from pypi [https://github.com/collective/collective.checkdocs]
+recipe = zc.recipe.egg
+eggs =
+    collective.checkdocs
 
 [zopeskel]
 # installs paster and Zopeskel


### PR DESCRIPTION
This will add https://github.com/collective/collective.checkdocs to develop.cfg, documentation on docs.plone.org for that is on the way too