### PR TITLE
Bugfix for status comand getting error message for init script

### DIFF
--- a/HISTORY.txt
+++ b/HISTORY.txt
@@ -1,3 +1,7 @@
+5.0.5 undefinded
+
+- Bugfix for status comand getting error message for init script by RedHat-FedoraCore [terapyon]
+
 5.0.4-r1 20160425
 
 - Adjust CFLAGS for OS X to do less. Works better for El Capitan, may foul up earlier versions.

--- a/init_scripts/RedHat-FedoraCore/plone-cluster
+++ b/init_scripts/RedHat-FedoraCore/plone-cluster
@@ -46,6 +46,12 @@ stop() {
     return $?
 }
 
+status() {
+    echo "ZEO Server:"
+    ${clusterpath}/bin/plonectl status
+    return $?
+}
+
 restart() {
    stop
    start
@@ -59,9 +65,7 @@ case "$1" in
     stop
     ;;
   status)
-    echo "ZEO Server:"
-    ${clusterpath}/bin/plonectl status
-    return $?
+    status
     ;;
   restart)
     restart


### PR DESCRIPTION
I'm using `init_scripts/RedHat-FedoraCore/plone-cluster`. 
I call `$ sudo service plone status`. But I got error message, it is `/etc/init.d/plone: line 64: return: can only `return' from a function or sourced script`

I think it should make `status()` function like plone-cluster-user script or it should remove `return $?` code.