### PR TITLE
add --overwrite-cache option

### DIFF
--- a/helper_scripts/locales/en/LC_MESSAGES/messages.sh
+++ b/helper_scripts/locales/en/LC_MESSAGES/messages.sh
@@ -292,7 +292,8 @@ INSTALLING_SETUPTOOLS='Installing setuptools in virtual environment.'
 
 INSTALLING_SETUPTOOLS_FAILED='Unable to install setuptools in virtual environment.'
 
-FOUND_BUILDOUT_CACHE='Found existing buildout cache at $BUILDOUT_CACHE\; skipping step.'
+FOUND_BUILDOUT_CACHE='Found existing buildout cache at $BUILDOUT_CACHE\; skipping step.
+To force extraction, use the --overwrite-cache option.'
 
 UNPACKING_BUILDOUT_CACHE='Unpacking buildout cache to $BUILDOUT_CACHE'
 

--- a/helper_scripts/main_install_script.sh
+++ b/helper_scripts/main_install_script.sh
@@ -105,6 +105,7 @@ CLIENT_COUNT=2
 TEMPLATE=buildout
 WITHOUT_SSL="no"
 INSTALL_ZEO=0
+OVERWRITE_CACHE="no"
 
 USE_WHIPTAIL=0
 if [ "$BASH_VERSION" ] && [ "X$1" == "X" ]; then
@@ -257,6 +258,10 @@ do
             else
                 usage
             fi
+            ;;
+
+        --overwrite-cache )
+            OVERWRITE_CACHE=yes
             ;;
 
         --debug-options )
@@ -661,6 +666,7 @@ if [ "X$DEBUG_OPTIONS" = "Xyes" ]; then
     echo "PACKAGES_DIR=$PACKAGES_DIR"
     echo "ONLINE_PACKAGES_DIR=$ONLINE_PACKAGES_DIR"
     echo "HSCRIPTS_DIR=$HSCRIPTS_DIR"
+    echo "OVERWRITE_CACHE=$OVERWRITE_CACHE"
     echo "ROOT_INSTALL=$ROOT_INSTALL"
     echo "PLONE_HOME=$PLONE_HOME"
     echo "DAEMON_USER=$DAEMON_USER"
@@ -859,7 +865,7 @@ fi
 BUILDOUT_CACHE="$PLONE_HOME/buildout-cache"
 BUILDOUT_DIST="$PLONE_HOME/buildout-cache/downloads/dist"
 if [ -f "${PKG}/buildout-cache.tar.bz2" ]; then
-    if [ -x "$BUILDOUT_CACHE" ]; then
+    if [ -x "$BUILDOUT_CACHE" -a "$OVERWRITE_CACHE" = "no" ]; then
         eval "echo \"$FOUND_BUILDOUT_CACHE\""
     else
         eval "echo \"$UNPACKING_BUILDOUT_CACHE\""


### PR DESCRIPTION
I had previously installed Plone 5.0 into an instance at `/opt/plone/plone5_dev`, and later tried to install 5.1 into `/opt/plone/plone51_dev`, but buildout failed due to missing eggs.  I discovered this was due to:
```
Found existing buildout cache at /opt/plone/buildout-cache\; skipping step.
```
_(Yes, the `\;` is printed, but I assume that was done for a good reason, e.g. compatibility with non-bash sh?)_

My solution is to add an option that forces extraction of the buildout tarball, even if the cache directory exists.  As eggs are versioned, that should be reasonably safe, but I will leave the default to not do so.