### PR TITLE
Add versions spec of Zope 4.5.1

### DIFF
--- a/base_skeleton/Zope-releases-4.5.1-versions.cfg
+++ b/base_skeleton/Zope-releases-4.5.1-versions.cfg
@@ -1,0 +1,86 @@
+[buildout]
+extends =
+    versions-prod.cfg
+versions = versions
+
+[versions]
+# Version pins for development and optional dependencies.
+Babel = 2.8.0
+Jinja2 = 2.11.2
+MarkupSafe = 1.1.1
+# Pygments 2.6.0 and up require Python 3
+Pygments = 2.5.2
+# Version 2.0+ needs Python 3.x
+Sphinx = 1.8.5
+alabaster = 0.7.12
+appdirs = 1.4.4
+attrs = 19.3.0
+backports.functools-lru-cache = 1.6.1
+beautifulsoup4 = 4.9.1
+bleach = 3.1.5
+buildout.wheel = 0.2.0
+certifi = 2020.6.20
+cffi = 1.14.0
+chardet = 3.0.4
+cmarkgfm = 0.4.2
+collective.recipe.cmd = 0.11
+collective.recipe.sphinxbuilder = 1.1
+collective.recipe.template = 2.1
+colorama = 0.4.3
+# configparser 5 and up require Python 3
+configparser = 4.0.2
+contextlib2 = 0.6.0.post1
+coverage = 5.2
+distlib = 0.3.1
+docutils = 0.16
+filelock = 3.0.12
+idna = 2.10
+imagesize = 1.2.0
+# tox and pluggy require importlib-metadata <1
+importlib-metadata = 0.23
+lxml = 4.5.1
+manuel = 1.10.1
+# Version 6+ needs Python 3.x
+more-itertools = 5.0.0
+mr.developer = 2.0.0
+nose = 1.3.7
+packaging = 20.4
+pathlib2 = 2.3.5
+pip = 20.1.1
+pkginfo = 1.5.0.1
+plone.recipe.command = 1.1
+pluggy = 0.13.1
+py = 1.9.0
+pycparser = 2.20
+pyparsing = 2.4.7
+python-gettext = 4.0
+readme-renderer = 26.0
+repoze.sphinx.autointerface = 0.8
+requests = 2.24.0
+requests-toolbelt = 0.9.1
+scandir = 1.10.0
+snowballstemmer = 2.0.0
+# soupsieve 2 needs Python 3
+soupsieve = 1.9.6
+sphinx-rtd-theme = 0.5.0
+sphinxcontrib-websupport = 1.2.3
+# tempstorage is only needed because the Sphinx documentation parses
+# ZConfig xml configurations, which still contain references to it
+tempstorage = 5.1
+toml = 0.10.1
+tox = 3.16.1
+tqdm = 4.47.0
+# Version 2+ needs Python 3.x
+twine = 1.15.0
+typing = 3.7.4.1
+urllib3 = 1.25.9
+virtualenv = 20.0.26
+webencodings = 0.5.1
+wheel = 0.34.2
+z3c.checkversions = 1.2
+zc.recipe.egg = 2.0.7
+zc.recipe.testrunner = 2.1
+zest.releaser = 6.21.0
+# Version 2 requires Python 3
+zipp = 1.1.1
+zodbupdate = 1.5


### PR DESCRIPTION
... downloaded from https://zopefoundation.github.io/Zope/releases/4.5.1/versions.cfg
(thanks, Maurits)

fix #107 